### PR TITLE
Change d3 version to V3 to fix incompatibility in d3.time.scale

### DIFF
--- a/tmpl/layout.html
+++ b/tmpl/layout.html
@@ -46,7 +46,7 @@
 <script src="https://cdn.jsdelivr.net/lodash/4.7.0/lodash.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
 <script src="/static/js/third/jquery-ui.min.js"></script>
 <script src="/static/js/third/math.min.js"></script>
 <script src="/static/js/third/async.min.js"></script>


### PR DESCRIPTION
Episode 7 gives an error since d3.time is not defined on [line 68 of scalar-time-chart.js](https://github.com/htm-community/htm-school-viz/blob/master/static/js/lib/utils/scalar-time-chart.js#L68)

`this.transformDateIntoXValue = d3.time.scale()`

The fix I found was to revert to d3 V3 in tmpl/layout.html  If you prefer, I could change the v3 calls to v4, but it might take a while.